### PR TITLE
Implement meson template

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Project management tool"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-structopt = "0.3"
-minijinja = { version = "0.5", features = ["source"] }
 anyhow = "1"
+minijinja = { version = "0.6", features = ["source"] }
+serde = { version = "1", features = ["derive"] }
+structopt = "0.3"

--- a/src/bin/sifis-tool.rs
+++ b/src/bin/sifis-tool.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use structopt::StructOpt;
 
+use sifis_tool::create_project;
+
 #[derive(StructOpt, Debug)]
 struct Opts {
     #[structopt(subcommand)]
@@ -24,5 +26,12 @@ enum Cmd {
 fn main() {
     let opts = Opts::from_args();
 
-    println!("{:?}", opts);
+    match opts.cmd {
+        Cmd::New {
+            template,
+            project_name,
+        } => {
+            create_project(&template, project_name.as_path()).unwrap();
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,57 @@
-use std::{collections::HashMap, path::PathBuf};
+mod meson;
 
-use minijinja::Source;
+use std::path::Path;
+use std::str::FromStr;
 
-/// Project template
-///
-/// A collection of templates with their destination paths within the project
-#[derive(Debug)]
-struct ProjectTemplate {
-    /// Contains the output path <-> template name association
-    files: HashMap<PathBuf, String>,
-    /// Storage for the templates
-    templates: Source,
+use anyhow::{bail, Result};
+
+use crate::meson::*;
+
+/// Supported templates
+enum Templates {
+    MesonC,
+    MesonCpp,
+}
+
+impl FromStr for Templates {
+    type Err = ();
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "meson-c" => Ok(Self::MesonC),
+            "meson-c++" => Ok(Self::MesonCpp),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Render a template
+trait RenderTemplate {
+    fn render(&self, project_name: &str) -> Result<()>;
+}
+
+/// Creates a new project
+pub fn create_project(template: &str, project_path: &Path) -> Result<()> {
+    let project_name = if let Some(os_name) = project_path.file_name() {
+        if let Some(name) = os_name.to_str() {
+            name
+        } else {
+            bail!("Impossible to convert the project name into a valid Unicode string");
+        }
+    } else {
+        bail!("Impossible to get the project name");
+    };
+
+    let template_type = if let Ok(template_type) = Templates::from_str(template) {
+        template_type
+    } else {
+        bail!("Wrong template name!");
+    };
+
+    let template_builder = match template_type {
+        Templates::MesonC => Meson::c_template(project_path),
+        Templates::MesonCpp => Meson::cpp_template(project_path),
+    };
+
+    template_builder.render(project_name)
 }

--- a/src/meson.rs
+++ b/src/meson.rs
@@ -1,0 +1,198 @@
+use std::collections::HashMap;
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+use minijinja::{Environment, Source};
+use serde::Serialize;
+
+use crate::RenderTemplate;
+
+const MESON_FILE: &str = "meson.build";
+
+struct Template<'a> {
+    name: &'a str,
+    template: &'a str,
+}
+
+#[derive(Serialize)]
+struct Context<'a> {
+    name: &'a str,
+    exe: &'a str,
+    params: &'a str,
+}
+
+pub(crate) struct Meson<'a> {
+    template_files: HashMap<PathBuf, Template<'a>>,
+    other_files: HashMap<PathBuf, String>,
+    dirs: [PathBuf; 5],
+    is_c: bool,
+}
+
+impl<'a> Meson<'a> {
+    pub(crate) fn c_template(project_path: &Path) -> Self {
+        let dirs = Self::get_dirs(project_path);
+        Self {
+            template_files: Self::get_template_files(&dirs[0], &dirs[1], &dirs[2], &dirs[3]),
+            other_files: Self::get_other_files(&dirs[1], &dirs[2], &dirs[3], &dirs[4], true),
+            dirs,
+            is_c: true,
+        }
+    }
+
+    pub(crate) fn cpp_template(project_path: &Path) -> Self {
+        let dirs = Self::get_dirs(project_path);
+        Self {
+            template_files: Self::get_template_files(&dirs[0], &dirs[1], &dirs[2], &dirs[3]),
+            other_files: Self::get_other_files(&dirs[1], &dirs[2], &dirs[3], &dirs[4], false),
+            dirs,
+            is_c: false,
+        }
+    }
+
+    fn get_template_files(
+        root: &Path,
+        cli: &Path,
+        lib: &Path,
+        tests: &Path,
+    ) -> HashMap<PathBuf, Template<'a>> {
+        let mut template_files = HashMap::new();
+        template_files.insert(
+            root.join(MESON_FILE),
+            Template {
+                name: "root",
+                template: include_str!("../templates/meson/root.build"),
+            },
+        );
+        template_files.insert(
+            cli.join(MESON_FILE),
+            Template {
+                name: "cli",
+                template: include_str!("../templates/meson/cli.build"),
+            },
+        );
+        template_files.insert(
+            lib.join(MESON_FILE),
+            Template {
+                name: "lib",
+                template: include_str!("../templates/meson/lib.build"),
+            },
+        );
+        template_files.insert(
+            tests.join(MESON_FILE),
+            Template {
+                name: "tests",
+                template: include_str!("../templates/meson/tests.build"),
+            },
+        );
+        template_files
+    }
+
+    fn get_dirs(project_path: &Path) -> [PathBuf; 5] {
+        [
+            project_path.to_path_buf(),
+            project_path.join("cli"),
+            project_path.join("lib"),
+            project_path.join("tests"),
+            project_path.join(".github/workflows"),
+        ]
+    }
+
+    fn get_other_files(
+        cli: &Path,
+        lib: &Path,
+        tests: &Path,
+        ci: &Path,
+        is_c: bool,
+    ) -> HashMap<PathBuf, String> {
+        let mut other_files = HashMap::new();
+        other_files.insert(
+            lib.join("foo.h"),
+            include_str!("../templates/meson/foo.h").to_owned(),
+        );
+        other_files.insert(
+            lib.join(if is_c { "foo.c" } else { "foo.cpp" }),
+            include_str!("../templates/meson/foo").to_owned(),
+        );
+        other_files.insert(
+            cli.join(if is_c { "main.c" } else { "main.cpp" }),
+            include_str!("../templates/meson/main").to_owned(),
+        );
+        other_files.insert(
+            tests.join(if is_c { "test.c" } else { "test.cpp" }),
+            include_str!("../templates/meson/test").to_owned(),
+        );
+        other_files.insert(
+            ci.join("ci.yml"),
+            include_str!("../templates/meson/ci.yml").to_owned(),
+        );
+        other_files
+    }
+}
+
+impl<'a> RenderTemplate for Meson<'a> {
+    fn render(&self, project_name: &str) -> Result<()> {
+        let mut env = Environment::new();
+        let mut templates = Source::new();
+
+        // Create dirs
+        for dir in self.dirs.iter() {
+            create_dir_all(dir)?
+        }
+
+        // Define templates
+        for template_data in self.template_files.values() {
+            // Define templates
+            if templates
+                .add_template(template_data.name, template_data.template)
+                .is_err()
+            {
+                bail!("Wrong template definition!");
+            }
+        }
+        env.set_source(templates);
+
+        // Define context
+        let context = if self.is_c {
+            Context {
+                name: project_name,
+                exe: "c",
+                params: "c_std=c99",
+            }
+        } else {
+            Context {
+                name: project_name,
+                exe: "cpp",
+                params: "cpp_std=c++11",
+            }
+        };
+
+        // Fill in templates
+        for (path, template_data) in &self.template_files {
+            let template = if let Ok(template) = env.get_template(template_data.name) {
+                template
+            } else {
+                bail!("Error getting {} template!", template_data.name);
+            };
+            if let Ok(filled_template) = template.render(&context) {
+                write_file(path, &filled_template)?;
+            } else {
+                bail!("Error rendering {} template!", template_data.name);
+            }
+        }
+
+        // Create other files
+        for (path, data) in &self.other_files {
+            write_file(path, data)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn write_file(file_path: &Path, data: &str) -> Result<()> {
+    let mut file = File::create(file_path)?;
+    file.write_all(data.as_bytes())?;
+    Ok(())
+}

--- a/templates/meson/ci.yml
+++ b/templates/meson/ci.yml
@@ -1,0 +1,57 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  workflow-steps:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up last Python version
+      uses: actions/setup-python@v2
+
+    - name: Install meson, ninja and gcovr
+      run: |
+        pip install meson ninja gcovr
+
+    - name: Create build directory and configure settings
+      run: |
+        meson setup --buildtype release .build-directory
+
+    - name: Build the project
+      run: |
+        meson compile -C .build-directory
+
+    - name: Create a test and code coverage directory
+      run: |
+        meson setup -Db_coverage=true .build-directory-coverage
+
+    - name: Run code coverage tests
+      run: |
+        meson test -C .build-directory-coverage
+
+    - name: Export the code coverage as xml file
+      run: |
+        ninja coverage-xml -C .build-directory-coverage
+
+    - name: Create an address sanitizer instrumented build directory
+      run: |
+        meson setup --buildtype release -Db_sanitize=address -Db_lundef=false .build-directory-asan
+
+    - name: Run address sanitizer instrumented tests
+      run: |
+        meson test -C .build-directory-asan
+
+    - name: Update coverage.xml
+      uses: actions/upload-artifact@v2
+      with:
+        name: coverage
+        path: |
+          .build-directory-coverage/meson-logs/coverage.xml

--- a/templates/meson/cli.build
+++ b/templates/meson/cli.build
@@ -1,0 +1,11 @@
+# C files contained in the directory
+cli_src = files('main.{{ exe }}')
+
+# Create a new executable
+foo_cli = executable(
+    '{{ name }}', # Executable name
+    cli_src, # Executable files
+    install: true, # Install the executable in some default filesystem positions
+    include_directories: incs, # Directories to be included when building the executable
+    dependencies: foo_dep # Libraries to be linked at the executable
+)

--- a/templates/meson/foo
+++ b/templates/meson/foo
@@ -1,0 +1,1 @@
+#include "foo.h"

--- a/templates/meson/foo.h
+++ b/templates/meson/foo.h
@@ -1,0 +1,4 @@
+#ifndef FOO_H
+#define FOO_H
+
+#endif

--- a/templates/meson/lib.build
+++ b/templates/meson/lib.build
@@ -1,0 +1,20 @@
+# C files contained in the directory
+lib_src = files(
+    'foo.{{ exe }}',
+)
+
+# Creates the libfoo library
+foo = library(
+    'lib{{ name }}', # Library name
+    sources: [lib_src], # Source files to build the library
+    install: true, # Install the library in some default filesystem positions
+    include_directories: incs # Directories to be included when building the library
+)
+
+# Creates a new dependency object.
+# The object allows the foo library to be linked with external executables or 
+# libraries, practically this object treats the foo library as a dependency
+foo_dep = declare_dependency(
+    link_with: foo, # Name of the library that needs to be linked
+    include_directories: incs, # Directories to be included when linking the library
+)

--- a/templates/meson/main
+++ b/templates/meson/main
@@ -1,0 +1,6 @@
+#include "foo.h"
+
+int main()
+{
+
+}

--- a/templates/meson/root.build
+++ b/templates/meson/root.build
@@ -1,0 +1,31 @@
+# Project metadata
+project(
+    '{{ name }}', # Project name
+    '{{ exe }}', # Programming language
+    license: 'MIT', # Project license
+    meson_version: '>= 0.49.0', # Allowed meson versions to build the project
+    default_options: ['{{ params }}', 'warning_level=3'], # C/Cpp language standard to use and warning level
+    version: '0.1.0' # Project version
+)
+
+# Gets compiler
+compiler = meson.get_compiler('{{ exe }}')
+
+# Sets compiler flags
+flags = [
+    '-pedantic'
+]
+
+# Returns an array containing only the arguments supported by the compiler
+supported_arguments = compiler.get_supported_arguments(flags)
+
+# Adds the positional arguments to the compiler command line
+add_project_arguments(supported_arguments, language: '{{ exe }}')
+
+# Returns an object containing the directories considered in the project
+incs = include_directories('.', 'lib', 'cli')
+
+# Enters the specified subdirectories and executes their meson.build file.
+subdir('lib')
+subdir('cli')
+subdir('tests')

--- a/templates/meson/test
+++ b/templates/meson/test
@@ -1,0 +1,6 @@
+#include "foo.h"
+
+int main()
+{
+
+}

--- a/templates/meson/tests.build
+++ b/templates/meson/tests.build
@@ -1,0 +1,13 @@
+# Create a new executable object to test the library
+exe = executable(
+  'test-{{ name }}', # Executable name
+  'test.{{ exe }}', # Tests source file
+  include_directories: incs, # Directories to be included when building the executable
+  dependencies: foo_dep # Libraries to be linked at the executable
+)
+
+# Create a test that run all tests contained in the executable produced above
+test(
+  'test_name', # Test name
+  exe # Executable object
+)


### PR DESCRIPTION
The meson template defines a typical meson project structure that contains `meson.build` files for `cli`, `lib` and `tests` directories. Furthermore, a `GitHub Actions` CI has been implemented. 

Two templates can be generated:
- `C` code using `sifis-tool --template meson-c project_dir`
- `C++` code using `sifis-tool --template meson-c++ project_dir`

This PR fixes part of #1 