### PR TITLE
Refactor the meson support

### DIFF
--- a/src/bin/sifis-tool.rs
+++ b/src/bin/sifis-tool.rs
@@ -23,15 +23,15 @@ enum Cmd {
     },
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let opts = Opts::from_args();
 
     match opts.cmd {
         Cmd::New {
             template,
             project_name,
-        } => {
-            create_project(&template, project_name.as_path()).unwrap();
-        }
+        } => create_project(&template, project_name.as_path())?,
     }
+
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ impl FromStr for Templates {
 
 /// Render a template
 trait RenderTemplate {
-    fn render(&self, project_name: &str) -> Result<()>;
+    fn render(&self, project_path: &Path, project_name: &str) -> Result<()>;
 }
 
 /// Creates a new project
@@ -49,9 +49,9 @@ pub fn create_project(template: &str, project_path: &Path) -> Result<()> {
     };
 
     let template_builder = match template_type {
-        Templates::MesonC => Meson::c_template(project_path),
-        Templates::MesonCpp => Meson::cpp_template(project_path),
+        Templates::MesonC => Meson::with_kind(ProjectKind::C),
+        Templates::MesonCpp => Meson::with_kind(ProjectKind::Cxx),
     };
 
-    template_builder.render(project_name)
+    template_builder.render(project_path, project_name)
 }

--- a/templates/meson/bin
+++ b/templates/meson/bin
@@ -1,0 +1,6 @@
+#include "{{ name ~ ".h" }}"
+
+int main()
+{
+
+}

--- a/templates/meson/cli.build
+++ b/templates/meson/cli.build
@@ -1,11 +1,11 @@
 # C files contained in the directory
-cli_src = files('main.{{ exe }}')
+cli_src = files('{{ name }}.{{ exe }}')
 
 # Create a new executable
-foo_cli = executable(
+{{ name }}_cli = executable(
     '{{ name }}', # Executable name
     cli_src, # Executable files
     install: true, # Install the executable in some default filesystem positions
     include_directories: incs, # Directories to be included when building the executable
-    dependencies: foo_dep # Libraries to be linked at the executable
+    dependencies: {{ name }}_dep # Libraries to be linked at the executable
 )

--- a/templates/meson/foo
+++ b/templates/meson/foo
@@ -1,1 +1,0 @@
-#include "foo.h"

--- a/templates/meson/foo.h
+++ b/templates/meson/foo.h
@@ -1,4 +1,0 @@
-#ifndef FOO_H
-#define FOO_H
-
-#endif

--- a/templates/meson/github.yml
+++ b/templates/meson/github.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest]
 
-    runs-on: ${{ matrix.platform }}
+    runs-on: {{ '${{ matrix.platform }}' }}
 
     steps:
     - uses: actions/checkout@v2

--- a/templates/meson/header
+++ b/templates/meson/header
@@ -1,0 +1,5 @@
+{% with guard = name | upper ~ "_H" %}
+#ifndef {{ guard }}
+#define {{ guard }}
+#endif // {{ guard }}
+{% endwith %}

--- a/templates/meson/lib
+++ b/templates/meson/lib
@@ -1,0 +1,1 @@
+#include "{{ name ~ ".h" }}"

--- a/templates/meson/lib.build
+++ b/templates/meson/lib.build
@@ -1,10 +1,10 @@
 # C files contained in the directory
 lib_src = files(
-    'foo.{{ exe }}',
+    '{{ name }}.{{ exe }}',
 )
 
 # Creates the libfoo library
-foo = library(
+{{ name }} = library(
     'lib{{ name }}', # Library name
     sources: [lib_src], # Source files to build the library
     install: true, # Install the library in some default filesystem positions
@@ -12,9 +12,9 @@ foo = library(
 )
 
 # Creates a new dependency object.
-# The object allows the foo library to be linked with external executables or 
+# The object allows the foo library to be linked with external executables or
 # libraries, practically this object treats the foo library as a dependency
-foo_dep = declare_dependency(
-    link_with: foo, # Name of the library that needs to be linked
+{{ name }}_dep = declare_dependency(
+    link_with: {{ name }}, # Name of the library that needs to be linked
     include_directories: incs, # Directories to be included when linking the library
 )

--- a/templates/meson/main
+++ b/templates/meson/main
@@ -1,6 +1,0 @@
-#include "foo.h"
-
-int main()
-{
-
-}

--- a/templates/meson/test
+++ b/templates/meson/test
@@ -1,6 +1,6 @@
-#include "foo.h"
+#include "{{ name ~ ".h"}}"
 
 int main()
 {
-
+    return 0;
 }

--- a/templates/meson/tests.build
+++ b/templates/meson/tests.build
@@ -1,9 +1,9 @@
 # Create a new executable object to test the library
 exe = executable(
   'test-{{ name }}', # Executable name
-  'test.{{ exe }}', # Tests source file
+  '{{ name }}.{{ exe }}', # Tests source file
   include_directories: incs, # Directories to be included when building the executable
-  dependencies: foo_dep # Libraries to be linked at the executable
+  dependencies: {{ name }}_dep # Libraries to be linked at the executable
 )
 
 # Create a test that run all tests contained in the executable produced above


### PR DESCRIPTION
- Make the template generate files with the names derived from the
  project name
- Always use templates to simplify the code-flow
- Prepare to support inheriting