### PR TITLE
License support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ anyhow = "1"
 minijinja = { version = "0.7", features = ["source"] }
 serde = { version = "1", features = ["derive"] }
 structopt = "0.3"
+license = "1.1"

--- a/src/bin/sifis-generate.rs
+++ b/src/bin/sifis-generate.rs
@@ -10,10 +10,19 @@ struct Opts {
     cmd: Cmd,
 }
 
+fn from_id(id: &str) -> anyhow::Result<String> {
+    license::from_id(id)
+        .map(|_| id.to_owned())
+        .ok_or_else(|| anyhow::anyhow!("License not found"))
+}
+
 #[derive(StructOpt, Debug)]
 enum Cmd {
     /// Create a new project
     New {
+        /// License to be used in the project
+        #[structopt(long, short, parse(try_from_str = from_id), default_value = "MIT")]
+        license: String,
         /// Name of a builtin template
         #[structopt(long, short)]
         template: String,
@@ -30,7 +39,8 @@ fn main() -> anyhow::Result<()> {
         Cmd::New {
             template,
             project_name,
-        } => create_project(&template, project_name.as_path())?,
+            license,
+        } => create_project(&template, project_name.as_path(), &license)?,
     }
 
     Ok(())

--- a/src/meson.rs
+++ b/src/meson.rs
@@ -55,6 +55,7 @@ impl Meson {
         let mut template_files = HashMap::new();
         // All the files in the root of the projects
         template_files.insert(root.join(MESON_FILE), "build.root");
+        template_files.insert(root.join("LICENSE"), "build.license");
 
         // All the files in the `cli/` directory of the project
         template_files.insert(cli.join(MESON_FILE), "build.cli");

--- a/templates/meson/bin
+++ b/templates/meson/bin
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: {{ license.id }}
 #include "{{ name ~ ".h" }}"
 
 int main()

--- a/templates/meson/header
+++ b/templates/meson/header
@@ -1,4 +1,5 @@
-{% with guard = name | upper ~ "_H" %}
+// SPDX-License-Identifier: {{ license.id }}
+{%- with guard = name | upper ~ "_H" -%}
 #ifndef {{ guard }}
 #define {{ guard }}
 #endif // {{ guard }}

--- a/templates/meson/lib
+++ b/templates/meson/lib
@@ -1,1 +1,2 @@
+// SPDX-License-Identifier: {{ license.id }}
 #include "{{ name ~ ".h" }}"

--- a/templates/meson/test
+++ b/templates/meson/test
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: {{ license.id }}
 #include "{{ name ~ ".h"}}"
 
 int main()


### PR DESCRIPTION
#14 should land first.

```
sifis-generate-new 0.1.0
Create a new project

USAGE:
    sifis-generate new [OPTIONS] <project-name> --template <template>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -l, --license <license>      License to be used in the project [default: MIT]
    -t, --template <template>    Name of a builtin template

ARGS:
    <project-name>    Path to the new project
```