### PR TITLE
cargo-ci: Add rust code analysis to GitHub CI

### DIFF
--- a/templates/cargo/github.yml
+++ b/templates/cargo/github.yml
@@ -61,3 +61,59 @@ jobs:
 
     - name: Generate docs
       run: cargo doc --no-deps
+
+  rust-code-analysis:
+
+    env:
+      RCA_LINK: https://github.com/mozilla/rust-code-analysis/releases/download
+      RCA_VERSION: v0.0.23
+
+    strategy:
+      matrix:
+        conf:
+          - ubuntu
+          - windows
+        include:
+          - conf: ubuntu
+            os: ubuntu-latest
+            rca-dir: .local/bin
+            rca-binary: rust-code-analysis-linux-cli-x86_64.tar.gz
+            rca-output-dir: rca-json
+          - conf: windows
+            os: windows-latest
+            rca-dir: bin
+            rca-binary: rust-code-analysis-win-cli-x86_64.zip
+            rca-output-dir: rca-json
+
+    runs-on: {{ '${{ matrix.os }}' }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install rust-code-analysis on Ubuntu
+      if: matrix.conf == 'ubuntu'
+      run: |
+        mkdir -p $HOME/{{ '${{ matrix.rca-dir }}' }}
+        curl -L "$RCA_LINK/$RCA_VERSION/{{ '${{ matrix.rca-binary }}' }}" |
+        tar xz -C $HOME/{{ '${{ matrix.rca-dir }}' }}
+        echo "$HOME/{{ '${{ matrix.rca-dir }}' }}" >> $GITHUB_PATH
+
+    - name: Install rust-code-analysis on Windows
+      if: matrix.conf == 'windows'
+      run: |
+        mkdir -p $HOME/{{ '${{ matrix.rca-dir }}' }}
+        curl -LO "$Env:RCA_LINK/$env:RCA_VERSION/{{ '${{ matrix.rca-binary }}' }}"
+        7z e -y "{{ '${{ matrix.rca-binary }}' }}" -o"$HOME/{{ '${{ matrix.rca-dir }}' }}"
+        echo "$HOME/{{ '${{ matrix.rca-dir }}' }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Run rust-code-analysis
+      run: |
+        mkdir $HOME/{{ '${{ matrix.rca-output-dir }}' }}
+        # FIXME: Update rca version to analyze the entire directory of a repo
+        rust-code-analysis-cli --metrics -O json --pr -o "$HOME/{{ '${{ matrix.rca-output-dir }}' }}" -p src/
+
+    - name: Upload rust-code-analysis json
+      uses: actions/upload-artifact@v3
+      with:
+        name: {{ '${{ matrix.rca-output-dir }}' }}-{{ '${{ matrix.conf }}' }}
+        path: ~/{{ '${{ matrix.rca-output-dir }}' }}


### PR DESCRIPTION
This PR adds `rust-code-analysis` to GitHub Actions CI for `cargo`. It does not work on projects with workspaces because of a `rust-code-analysis` issue