### PR TITLE
cargo-ci: Split ci configuration per architectures

### DIFF
--- a/src/toolchain/cargo.rs
+++ b/src/toolchain/cargo.rs
@@ -7,7 +7,9 @@ use crate::{builtin_templates, BuildTemplate};
 
 static CARGO_TEMPLATES: &[(&str, &str)] = &builtin_templates!["cargo" =>
     ("ci.gitlab", ".gitlab-ci.yml"),
-    ("ci.github", "github.yml")
+    ("ci.github.ubuntu", "github-ubuntu.yml"),
+    ("ci.github.macos", "github-macos.yml"),
+    ("ci.github.windows", "github-windows.yml")
 ];
 
 pub(crate) struct Cargo;
@@ -28,7 +30,18 @@ impl Cargo {
 
         // Continuous Integration
         template_files.insert(root.join(".gitlab-ci.yml"), "ci.gitlab");
-        template_files.insert(github.join(format!("{}.yml", name)), "ci.github");
+        template_files.insert(
+            github.join(format!("{}-ubuntu.yml", name)),
+            "ci.github.ubuntu",
+        );
+        template_files.insert(
+            github.join(format!("{}-macos.yml", name)),
+            "ci.github.macos",
+        );
+        template_files.insert(
+            github.join(format!("{}-windows.yml", name)),
+            "ci.github.windows",
+        );
 
         (template_files, vec![root, github])
     }

--- a/templates/cargo/github-macos.yml
+++ b/templates/cargo/github-macos.yml
@@ -1,0 +1,252 @@
+#FIXME
+# - valgrind cannot be installed on macos, only on linux
+# - rust-code-analysis is not tested on macos, so no static analysis
+
+name: {{ name }}-macos
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clippy-rustfmt:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy, rustfmt
+
+    - name: Run rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check --verbose
+
+    - name: Run cargo clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+        args: --all-targets --tests --benches -- -D warnings
+
+  build-test:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Build
+      run: cargo build --verbose --tests --benches
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Generate docs
+      run: cargo doc --no-deps
+
+  code-coverage:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Install grcov
+      env:
+        GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
+        GRCOV_VERSION: v0.8.7
+      run: |
+        curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-apple-darwin.tar.bz2" |
+        tar xj -C $HOME/.cargo/bin
+
+    - name: Install llvm-tools-preview
+      run: |
+        rustup component add llvm-tools-preview
+
+    # Not necessary on a newly created image, but strictly advised
+    - name: Run cargo clean
+      run: |
+        cargo clean
+
+    - name: Run tests
+      env:
+        RUSTFLAGS: "-Cinstrument-coverage"
+        LLVM_PROFILE_FILE: "{{ name }}-%p-%m.profraw"
+      run: |
+        cargo test --verbose
+
+    - name: Run grcov
+      run: |
+        grcov . --binary-path ./target/debug/ -t covdir -s . --token YOUR_COVDIR_TOKEN > covdir.json
+
+    - name: Evaluate code coverage value
+      shell: bash
+      run: |
+        # Retrieve code coverage associated to the repository
+        FLOAT_COVERAGE=$(jq '.coveragePercent' covdir.json)
+        # Round the float value to the nearest value
+        COVERAGE_OUTPUT=$(printf "%.0f" $FLOAT_COVERAGE)
+        # If code coverage >= 80, green traffic light
+        if [ $COVERAGE_OUTPUT -ge 80 ]
+        then
+            echo "$COVERAGE_OUTPUT > 80 --> Green"
+        # If code coverage is >=60 but < 80, orange traffic light
+        elif [ $COVERAGE_OUTPUT -ge 60 ]
+        then
+            echo "60 <= $COVERAGE_OUTPUT < 80 --> Orange"
+        # Otherwise, red traffic light
+        else
+            echo "$COVERAGE_OUTPUT < 60 --> Red"
+            exit 1
+        fi
+
+
+  undefined-behaviour-fuzzy-dynamic-analysis:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache produced data
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: {{ '${{ runner.os }}' }}-cargo-ci-{{ "${{ hashFiles('**/Cargo.toml') }}" }}
+
+    - name: Install Rust nightly and miri
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        components: miri
+        override: true
+
+    # FIXME Use binaries
+    - name: Install cargo-fuzz
+      run: |
+        cargo install cargo-fuzz
+
+    - name: Run miri
+      env:
+        # -Zrandomize-layout makes sure not to rely on the layout of anything
+        # that might change
+        RUSTFLAGS: -Zrandomize-layout
+        # -Zmiri-check-number-validity enables checking of integer and float
+        # validity (e.g., they must be initialized and not carry
+        # pointer provenance) as part of enforcing validity invariants.
+        # -Zmiri-tag-raw-pointers enables a lot of extra UB checks relating
+        # to raw pointer aliasing rules.
+        # -Zmiri-symbolic-alignment-check makes the alignment check more strict.
+        MIRIFLAGS: >
+          -Zmiri-check-number-validity -Zmiri-tag-raw-pointers
+          -Zmiri-symbolic-alignment-check
+      run: cargo miri test
+
+    # FIXME Create a template with a dummy series of fuzzy tests
+    - name: Init cargo-fuzz
+      run: cargo fuzz init
+
+    - name: Run cargo-fuzz
+      run: cargo fuzz build
+
+    # Usage of the `help` command as base command, please replace it
+    # with the effective command that AddressSanitizer has to analyze
+    - name: Run AddressSanitizer
+      env:
+        RUSTFLAGS: -Zsanitizer=address
+        RUSTDOCFLAGS: -Zsanitizer=address
+      run: cargo run -Zbuild-std --target x86_64-apple-darwin -- --help
+
+  weighted-code-coverage:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Install grcov
+      env:
+        GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
+        GRCOV_VERSION: v0.8.7
+        GRCOV_BINARY: grcov-x86_64-apple-darwin.tar.bz2
+      run: |
+        curl -L "$GRCOV_LINK/$GRCOV_VERSION/$GRCOV_BINARY" |
+        tar xj -C $HOME/.cargo/bin
+
+    - name: Install weighted-code-coverage
+      env:
+        WCC_LINK: https://github.com/giovannitangredi/weighted-code-coverage/releases/download
+        WCC_VERSION: v0.1.0
+        WCC_BINARY: weighted-code-coverage-0.1.0-x86_64-apple-darwin.tar.gz
+      run: |
+        curl -L "$WCC_LINK/$WCC_VERSION/$WCC_BINARY" |
+        tar xz -C $HOME/.cargo/bin
+
+    - name: Install llvm-tools-preview
+      run: |
+        rustup component add llvm-tools-preview
+
+    # Not necessary on a newly created image, but strictly advised
+    - name: Run cargo clean
+      run: |
+        cargo clean
+
+    - name: Run tests
+      env:
+        RUSTFLAGS: "-Cinstrument-coverage"
+        LLVM_PROFILE_FILE: "{{ name }}-%p-%m.profraw"
+      run: |
+        cargo test --verbose
+
+    - name: Run grcov
+      run: |
+        grcov . --binary-path ./target/debug/ -t coveralls -s . --token YOUR_COVERALLS_TOKEN > coveralls.json
+
+    - name: Run weighted-code-coverage
+      run: |
+        mkdir $HOME/wcc-output
+        weighted-code-coverage -p src/ -j coveralls.json -c --json $HOME/wcc-output/out.json
+
+    - name: Upload weighted-code-coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: weighted-code-coverage-macos
+        path: ~/wcc-output/out.json

--- a/templates/cargo/github-ubuntu.yml
+++ b/templates/cargo/github-ubuntu.yml
@@ -1,4 +1,4 @@
-name: {{ name }}
+name: {{ name }}-ubuntu
 
 on:
   push:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   clippy-rustfmt:
+
     runs-on: ubuntu-latest
 
     steps:
@@ -35,12 +36,9 @@ jobs:
         token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
         args: --all-targets --tests --benches -- -D warnings
 
-  build:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+  build-test:
 
-    runs-on: {{ '${{ matrix.platform }}' }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -63,24 +61,7 @@ jobs:
 
   code-coverage:
 
-    env:
-      GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
-      GRCOV_VERSION: v0.8.7
-
-    strategy:
-      matrix:
-        conf:
-          - ubuntu
-          - macos
-        include:
-          - conf: ubuntu
-            os: ubuntu-latest
-            grcov-binary: grcov-x86_64-unknown-linux-musl.tar.bz2
-          - conf: macos
-            os: macos-latest
-            grcov-binary: grcov-x86_64-apple-darwin.tar.bz2
-
-    runs-on: {{ '${{ matrix.os }}' }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -92,9 +73,12 @@ jobs:
         toolchain: stable
         override: true
 
-    - name: Install grcov on Unix
+    - name: Install grcov
+      env:
+        GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
+        GRCOV_VERSION: v0.8.7
       run: |
-        curl -L "$GRCOV_LINK/$GRCOV_VERSION/{{ '${{ matrix.grcov-binary }}' }}" |
+        curl -L "$GRCOV_LINK/$GRCOV_VERSION/grcov-x86_64-unknown-linux-musl.tar.bz2" |
         tar xj -C $HOME/.cargo/bin
 
     - name: Install llvm-tools-preview
@@ -137,7 +121,6 @@ jobs:
             echo "$COVERAGE_OUTPUT < 60 --> Red"
             exit 1
         fi
-
 
   memory-and-threads-dynamic-analysis:
 
@@ -230,95 +213,36 @@ jobs:
 
   static-code-analysis:
 
-    env:
-      RCA_LINK: https://github.com/mozilla/rust-code-analysis/releases/download
-      RCA_VERSION: v0.0.23
-
-    strategy:
-      matrix:
-        conf:
-          - ubuntu
-          - windows
-        include:
-          - conf: ubuntu
-            os: ubuntu-latest
-            rca-dir: .local/bin
-            rca-binary: rust-code-analysis-linux-cli-x86_64.tar.gz
-            rca-output-dir: rca-json
-          - conf: windows
-            os: windows-latest
-            rca-dir: bin
-            rca-binary: rust-code-analysis-win-cli-x86_64.zip
-            rca-output-dir: rca-json
-
-    runs-on: {{ '${{ matrix.os }}' }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Install rust-code-analysis on Ubuntu
-      if: matrix.conf == 'ubuntu'
+    - name: Install rust-code-analysis
+      env:
+        RCA_LINK: https://github.com/mozilla/rust-code-analysis/releases/download
+        RCA_VERSION: v0.0.23
       run: |
-        mkdir -p $HOME/{{ '${{ matrix.rca-dir }}' }}
-        curl -L "$RCA_LINK/$RCA_VERSION/{{ '${{ matrix.rca-binary }}' }}" |
-        tar xz -C $HOME/{{ '${{ matrix.rca-dir }}' }}
-        echo "$HOME/{{ '${{ matrix.rca-dir }}' }}" >> $GITHUB_PATH
-
-    - name: Install rust-code-analysis on Windows
-      if: matrix.conf == 'windows'
-      run: |
-        mkdir -p $HOME/{{ '${{ matrix.rca-dir }}' }}
-        curl -LO "$Env:RCA_LINK/$env:RCA_VERSION/{{ '${{ matrix.rca-binary }}' }}"
-        7z e -y "{{ '${{ matrix.rca-binary }}' }}" -o"$HOME/{{ '${{ matrix.rca-dir }}' }}"
-        echo "$HOME/{{ '${{ matrix.rca-dir }}' }}" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        mkdir -p $HOME/.local/bin
+        curl -L "$RCA_LINK/$RCA_VERSION/rust-code-analysis-linux-cli-x86_64.tar.gz" |
+        tar xz -C $HOME/.local/bin
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Run rust-code-analysis
       run: |
-        mkdir $HOME/{{ '${{ matrix.rca-output-dir }}' }}
+        mkdir $HOME/rca-json
         # FIXME: Update rca version to analyze the entire directory of a repo
-        rust-code-analysis-cli --metrics -O json --pr -o "$HOME/{{ '${{ matrix.rca-output-dir }}' }}" -p src/
+        rust-code-analysis-cli --metrics -O json --pr -o "$HOME/rca-json" -p src/
 
     - name: Upload rust-code-analysis json
       uses: actions/upload-artifact@v3
       with:
-        name: {{ '${{ matrix.rca-output-dir }}' }}-{{ '${{ matrix.conf }}' }}
-        path: ~/{{ '${{ matrix.rca-output-dir }}' }}
+        name: rca-json-ubuntu
+        path: ~/rca-json
 
   weighted-code-coverage:
 
-    env:
-      GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
-      GRCOV_VERSION: v0.8.7
-      WCC_LINK: https://github.com/giovannitangredi/weighted-code-coverage/releases/download
-      WCC_VERSION: v0.1.0
-
-    strategy:
-      matrix:
-        conf:
-          - ubuntu
-          - macos
-          - windows
-        include:
-          - conf: ubuntu
-            os: ubuntu-latest
-            grcov-binary: grcov-x86_64-unknown-linux-musl.tar.bz2
-            wcc-binary: weighted-code-coverage-0.1.0-x86_64-unknown-linux-gnu.tar.gz
-            wcc-output-dir: wcc-output
-            wcc-output-file: out.json
-          - conf: macos
-            os: macos-latest
-            grcov-binary: grcov-x86_64-apple-darwin.tar.bz2
-            wcc-binary: weighted-code-coverage-0.1.0-x86_64-apple-darwin.tar.gz
-            wcc-output-dir: wcc-output
-            wcc-output-file: out.json
-          - conf: windows
-            os: windows-latest
-            grcov-binary: grcov-x86_64-pc-windows-msvc.zip
-            wcc-binary: weighted-code-coverage-0.1.0-x86_64-pc-windows-msvc.zip
-            wcc-output-dir: wcc-output
-            wcc-output-file: out.json
-
-    runs-on: {{ '${{ matrix.os }}' }}
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -330,29 +254,23 @@ jobs:
         toolchain: stable
         override: true
 
-    - name: Install grcov on Unix
-      if: matrix.conf != 'windows'
+    - name: Install grcov
+      env:
+        GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
+        GRCOV_VERSION: v0.8.7
+        GRCOV_BINARY: grcov-x86_64-unknown-linux-musl.tar.bz2
       run: |
-        curl -L "$GRCOV_LINK/$GRCOV_VERSION/{{ '${{ matrix.grcov-binary }}' }}" |
+        curl -L "$GRCOV_LINK/$GRCOV_VERSION/$GRCOV_BINARY" |
         tar xj -C $HOME/.cargo/bin
 
-    - name: Install grcov on Windows
-      if: matrix.conf == 'windows'
+    - name: Install weighted-code-coverage
+      env:
+        WCC_LINK: https://github.com/giovannitangredi/weighted-code-coverage/releases/download
+        WCC_VERSION: v0.1.0
+        WCC_BINARY: weighted-code-coverage-0.1.0-x86_64-unknown-linux-gnu.tar.gz
       run: |
-        curl -LO "$Env:GRCOV_LINK/$Env:GRCOV_VERSION/{{ '${{ matrix.grcov-binary }}' }}"
-        7z e -y "{{ '${{ matrix.grcov-binary }}' }}" -o"${env:USERPROFILE}\.cargo\bin"
-
-    - name: Install weighted-code-coverage on Unix
-      if: matrix.conf != 'windows'
-      run: |
-        curl -L "$WCC_LINK/$WCC_VERSION/{{ '${{ matrix.wcc-binary }}' }}" |
+        curl -L "$WCC_LINK/$WCC_VERSION/$WCC_BINARY" |
         tar xz -C $HOME/.cargo/bin
-
-    - name: Install weighted-code-coverage on Windows
-      if: matrix.conf == 'windows'
-      run: |
-        curl -LO "$Env:WCC_LINK/$Env:WCC_VERSION/{{ '${{ matrix.wcc-binary }}' }}"
-        7z e -y "{{ '${{ matrix.wcc-binary }}' }}" -o"${env:USERPROFILE}\.cargo\bin"
 
     - name: Install llvm-tools-preview
       run: |
@@ -376,11 +294,11 @@ jobs:
 
     - name: Run weighted-code-coverage
       run: |
-        mkdir $HOME/{{ '${{ matrix.wcc-output-dir }}' }}
-        weighted-code-coverage -p src/ -j coveralls.json -c --json $HOME/{{ '${{ matrix.wcc-output-dir }}' }}/{{ '${{ matrix.wcc-output-file }}' }}
+        mkdir $HOME/wcc-output
+        weighted-code-coverage -p src/ -j coveralls.json -c --json $HOME/wcc-output/out.json
 
     - name: Upload weighted-code-coverage data
       uses: actions/upload-artifact@v3
       with:
-        name: weighted-code-coverage-{{ '${{ matrix.conf }}' }}
-        path: ~/{{ '${{ matrix.wcc-output-dir }}' }}/{{ '${{ matrix.wcc-output-file }}' }}
+        name: weighted-code-coverage-ubuntu
+        path: ~/wcc-output/out.json

--- a/templates/cargo/github-windows.yml
+++ b/templates/cargo/github-windows.yml
@@ -1,0 +1,204 @@
+# FIXME
+# - Code coverage on Windows does not work because there are problems
+#   with grcov paths
+# - valgrind cannot be installed on Windows, only on linux
+# - cargo-fuzz and AddressSanitizer are not supported on Windows
+
+name: {{ name }}-windows
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clippy-rustfmt:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy, rustfmt
+
+    - name: Run rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check --verbose
+
+    - name: Run cargo clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+        args: --all-targets --tests --benches -- -D warnings
+
+  build-test:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Build
+      run: cargo build --verbose --tests --benches
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Generate docs
+      run: cargo doc --no-deps
+
+  undefined-behaviour-dynamic-analysis:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Cache produced data
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: {{ '${{ runner.os }}' }}-cargo-ci-{{ "${{ hashFiles('**/Cargo.toml') }}" }}
+
+    - name: Install Rust nightly and miri
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        components: miri
+        override: true
+
+    # FIXME Use binaries
+    - name: Install cargo-fuzz
+      run: |
+        cargo install cargo-fuzz
+
+    - name: Run miri
+      env:
+        # -Zrandomize-layout makes sure not to rely on the layout of anything
+        # that might change
+        RUSTFLAGS: -Zrandomize-layout
+        # -Zmiri-check-number-validity enables checking of integer and float
+        # validity (e.g., they must be initialized and not carry
+        # pointer provenance) as part of enforcing validity invariants.
+        # -Zmiri-tag-raw-pointers enables a lot of extra UB checks relating
+        # to raw pointer aliasing rules.
+        # -Zmiri-symbolic-alignment-check makes the alignment check more strict.
+        MIRIFLAGS: >
+          -Zmiri-check-number-validity -Zmiri-tag-raw-pointers
+          -Zmiri-symbolic-alignment-check
+      run: cargo miri test
+
+  static-code-analysis:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install rust-code-analysis
+      env:
+        RCA_LINK: https://github.com/mozilla/rust-code-analysis/releases/download
+        RCA_VERSION: v0.0.23
+      run: |
+        mkdir -p $HOME/bin
+        curl -LO "$Env:RCA_LINK/$env:RCA_VERSION/rust-code-analysis-win-cli-x86_64.zip"
+        7z e -y "rust-code-analysis-win-cli-x86_64.zip" -o"$HOME/bin"
+        echo "$HOME/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Run rust-code-analysis
+      run: |
+        mkdir $HOME/rca-json
+        # FIXME: Update rca version to analyze the entire directory of a repo
+        rust-code-analysis-cli --metrics -O json --pr -o "$HOME/rca-json" -p src/
+
+    - name: Upload rust-code-analysis json
+      uses: actions/upload-artifact@v3
+      with:
+        name: rca-json-windows
+        path: ~/rca-json
+
+  weighted-code-coverage:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Install grcov
+      env:
+        GRCOV_LINK: https://github.com/mozilla/grcov/releases/download
+        GRCOV_VERSION: v0.8.7
+        GRCOV_BINARY: grcov-x86_64-pc-windows-msvc.zip 
+      run: |
+        curl -LO "$Env:GRCOV_LINK/$Env:GRCOV_VERSION/$Env:GRCOV_BINARY"
+        7z e -y "$Env:GRCOV_BINARY" -o"${env:USERPROFILE}\.cargo\bin"
+
+    - name: Install weighted-code-coverage
+      env:
+        WCC_LINK: https://github.com/giovannitangredi/weighted-code-coverage/releases/download
+        WCC_VERSION: v0.1.0
+        WCC_BINARY: weighted-code-coverage-0.1.0-x86_64-pc-windows-msvc.zip
+      run: |
+        curl -LO "$Env:WCC_LINK/$Env:WCC_VERSION/$Env:WCC_BINARY"
+        7z e -y "$Env:WCC_BINARY" -o"${env:USERPROFILE}\.cargo\bin"
+
+    - name: Install llvm-tools-preview
+      run: |
+        rustup component add llvm-tools-preview
+
+    # Not necessary on a newly created image, but strictly advised
+    - name: Run cargo clean
+      run: |
+        cargo clean
+
+    - name: Run tests
+      env:
+        RUSTFLAGS: "-Cinstrument-coverage"
+        LLVM_PROFILE_FILE: "{{ name }}-%p-%m.profraw"
+      run: |
+        cargo test --verbose
+
+    - name: Run grcov
+      run: |
+        grcov . --binary-path ./target/debug/ -t coveralls -s . --token YOUR_COVERALLS_TOKEN > coveralls.json
+
+    - name: Run weighted-code-coverage
+      run: |
+        mkdir $HOME/wcc-output
+        weighted-code-coverage -p src/ -j coveralls.json -c --json $HOME/wcc-output/out.json
+
+    - name: Upload weighted-code-coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: weighted-code-coverage-windows
+        path: ~/wcc-output/out.json


### PR DESCRIPTION
This PR splits single CI script into different scripts, one for each supported architecture.

This approach helps a developer to maintain the various jobs in an easier way, offering at the same time, the possibility to better discriminate among the tools used on a specific architecture and perhaps not on the other ones