### PR TITLE
cargo-ci: Add compact ci

### DIFF
--- a/src/toolchain/cargo.rs
+++ b/src/toolchain/cargo.rs
@@ -7,6 +7,7 @@ use crate::{builtin_templates, BuildTemplate};
 
 static CARGO_TEMPLATES: &[(&str, &str)] = &builtin_templates!["cargo" =>
     ("ci.gitlab", ".gitlab-ci.yml"),
+    ("ci.github.compact", "github-compact.yml"),
     ("ci.github.ubuntu", "github-ubuntu.yml"),
     ("ci.github.macos", "github-macos.yml"),
     ("ci.github.windows", "github-windows.yml")
@@ -30,6 +31,10 @@ impl Cargo {
 
         // Continuous Integration
         template_files.insert(root.join(".gitlab-ci.yml"), "ci.gitlab");
+        template_files.insert(
+            github.join(format!("{}-compact.yml", name)),
+            "ci.github.compact",
+        );
         template_files.insert(
             github.join(format!("{}-ubuntu.yml", name)),
             "ci.github.ubuntu",

--- a/templates/cargo/github-compact.yml
+++ b/templates/cargo/github-compact.yml
@@ -1,0 +1,68 @@
+name: {{ name }}-compact
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clippy-rustfmt:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: {{ '${{ matrix.platform }}' }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        components: clippy, rustfmt
+
+    - name: Run rustfmt
+      uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: -- --check --verbose
+
+    - name: Run cargo clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+        args: --all-targets --tests --benches -- -D warnings
+
+  build-test:
+
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: {{ '${{ matrix.platform }}' }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install Rust stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Build
+      run: cargo build --verbose --tests --benches
+
+    - name: Run tests
+      run: cargo test --verbose
+
+    - name: Generate docs
+      run: cargo doc --no-deps


### PR DESCRIPTION
This PR adds a compact CI for simple tests on the supported architectures